### PR TITLE
Forward ported the mapper from 2.0 release (as deprecated)

### DIFF
--- a/json-smart/pom.xml
+++ b/json-smart/pom.xml
@@ -47,7 +47,7 @@
 						<Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
 						<Bundle-Name>${project.artifactId}</Bundle-Name>
 						<Bundle-Version>${project.version}</Bundle-Version>
-						<Export-Package>net.minidev.json,net.minidev.json.annotate,net.minidev.json.mapper,net.minidev.json.parser,net.minidev.json.serialiser</Export-Package>
+						<Export-Package>net.minidev.json,net.minidev.json.annotate,net.minidev.json.mapper,net.minidev.json.parser,net.minidev.json.writer,net.minidev.json.reader,net.minidev.json.serialiser</Export-Package>
 						<!-- Private-Package></Private-Package -->
 					</instructions>
 				</configuration>

--- a/json-smart/src/main/java/net/minidev/json/mapper/AMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/AMapper.java
@@ -1,0 +1,99 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import net.minidev.json.parser.ParseException;
+import net.minidev.json.writer.JsonReaderI;
+/**
+ * Default datatype mapper use by Json-smart ton store data.
+ * 
+ * @author uriel Chemouni
+ *
+ * @param <T>
+ * @deprecated Use the {@link JsonReaderI} class.
+ */
+@Deprecated
+public abstract class AMapper<T> {
+	private static String ERR_MSG = "Invalid or non Implemented status";
+
+	/**
+	 * called when json-smart parser meet an object key
+	 */
+	public AMapper<?> startObject(String key) throws ParseException, IOException {
+		throw new RuntimeException(ERR_MSG);
+	}
+	/**
+	 * called when json-smart parser start an array.
+	 * 
+	 * @param key the destination key name, or null.
+	 */
+	public AMapper<?> startArray(String key) throws ParseException, IOException {
+		throw new RuntimeException(ERR_MSG);
+	}
+
+	/**
+	 * called when json-smart done parsing a value
+	 */
+	public void setValue(Object current, String key, Object value) throws ParseException, IOException {
+		throw new RuntimeException(ERR_MSG);
+	}
+
+	/**
+	 * -------------
+	 */
+	public Object getValue(Object current, String key) {
+		throw new RuntimeException(ERR_MSG);		
+	}
+
+	// Object current, 
+	public Type getType(String key) {
+		throw new RuntimeException(ERR_MSG);		
+	}
+
+	/**
+	 * add a value in an array json object.
+	 */
+	public void addValue(Object current, Object value) throws ParseException, IOException {
+		throw new RuntimeException(ERR_MSG);
+	}
+
+	/**
+	 * use to instantiate a new object that will be used as an object
+	 */
+	public Object createObject() {
+		throw new RuntimeException(ERR_MSG);
+	}
+
+	/**
+	 * use to instantiate a new object that will be used as an array
+	 */
+	public Object createArray() {
+		throw new RuntimeException(ERR_MSG);
+	}
+	
+	/**
+	 * Allow a mapper to converte a temprary structure to the final data format.
+	 * 
+	 * example: convert an List<Integer> to an int[]
+	 */
+	@SuppressWarnings("unchecked")
+	public T convert(Object current) {
+		return (T) current;
+	}
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/ArraysMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/ArraysMapper.java
@@ -1,0 +1,309 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.lang.reflect.Array;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * @param <T>
+ * @deprecated Use the {@link net.minidev.json.writer.ArraysMapper} class instead.
+ */
+@Deprecated
+public class ArraysMapper<T> extends AMapper<T> {
+	@Override
+	public Object createArray() {
+		return new ArrayList<Object>();
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void addValue(Object current, Object value) {
+		((List<Object>) current).add(value);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public T convert(Object current) {
+		return (T) current;
+	}
+
+	public static class GenericMapper<T> extends ArraysMapper<T> {
+		final Class<?> componentType;
+		AMapper<?> subMapper;
+
+		public GenericMapper(Class<T> type) {
+			this.componentType = type.getComponentType();
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public T convert(Object current) {
+			int p = 0;
+
+			Object[] r = (Object[]) Array.newInstance(componentType, ((List<?>) current).size());
+			for (Object e : ((List<?>) current))
+				r[p++] = e;
+			return (T) r;
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			if (subMapper == null)
+				subMapper = Mapper.getMapper(componentType);
+			return subMapper;
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			if (subMapper == null)
+				subMapper = Mapper.getMapper(componentType);
+			return subMapper;
+		}
+	};
+
+	public static AMapper<int[]> MAPPER_PRIM_INT = new ArraysMapper<int[]>() {
+		@Override
+		public int[] convert(Object current) {
+			int p = 0;
+			int[] r = new int[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Number) e).intValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Integer[]> MAPPER_INT = new ArraysMapper<Integer[]>() {
+		@Override
+		public Integer[] convert(Object current) {
+			int p = 0;
+			Integer[] r = new Integer[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Integer)
+					r[p] = (Integer) e;
+				else
+					r[p] = ((Number) e).intValue();
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<short[]> MAPPER_PRIM_SHORT = new ArraysMapper<short[]>() {
+		@Override
+		public short[] convert(Object current) {
+			int p = 0;
+			short[] r = new short[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Number) e).shortValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Short[]> MAPPER_SHORT = new ArraysMapper<Short[]>() {
+		@Override
+		public Short[] convert(Object current) {
+			int p = 0;
+			Short[] r = new Short[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Short)
+					r[p] = (Short) e;
+				else
+					r[p] = ((Number) e).shortValue();
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<byte[]> MAPPER_PRIM_BYTE = new ArraysMapper<byte[]>() {
+		@Override
+		public byte[] convert(Object current) {
+			int p = 0;
+			byte[] r = new byte[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Number) e).byteValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Byte[]> MAPPER_BYTE = new ArraysMapper<Byte[]>() {
+		@Override
+		public Byte[] convert(Object current) {
+			int p = 0;
+			Byte[] r = new Byte[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Byte)
+					r[p] = (Byte) e;
+				else
+					r[p] = ((Number) e).byteValue();
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<char[]> MAPPER_PRIM_CHAR = new ArraysMapper<char[]>() {
+		@Override
+		public char[] convert(Object current) {
+			int p = 0;
+			char[] r = new char[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = e.toString().charAt(0);
+			return r;
+		}
+	};
+
+	public static AMapper<Character[]> MAPPER_CHAR = new ArraysMapper<Character[]>() {
+		@Override
+		public Character[] convert(Object current) {
+			int p = 0;
+			Character[] r = new Character[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				r[p] = e.toString().charAt(0);
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<long[]> MAPPER_PRIM_LONG = new ArraysMapper<long[]>() {
+		@Override
+		public long[] convert(Object current) {
+			int p = 0;
+			long[] r = new long[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Number) e).intValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Long[]> MAPPER_LONG = new ArraysMapper<Long[]>() {
+		@Override
+		public Long[] convert(Object current) {
+			int p = 0;
+			Long[] r = new Long[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Float)
+					r[p] = ((Long) e);
+				else
+					r[p] = ((Number) e).longValue();
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<float[]> MAPPER_PRIM_FLOAT = new ArraysMapper<float[]>() {
+		@Override
+		public float[] convert(Object current) {
+			int p = 0;
+			float[] r = new float[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Number) e).floatValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Float[]> MAPPER_FLOAT = new ArraysMapper<Float[]>() {
+		@Override
+		public Float[] convert(Object current) {
+			int p = 0;
+			Float[] r = new Float[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Float)
+					r[p] = ((Float) e);
+				else
+					r[p] = ((Number) e).floatValue();
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<double[]> MAPPER_PRIM_DOUBLE = new ArraysMapper<double[]>() {
+		@Override
+		public double[] convert(Object current) {
+			int p = 0;
+			double[] r = new double[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Number) e).doubleValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Double[]> MAPPER_DOUBLE = new ArraysMapper<Double[]>() {
+		@Override
+		public Double[] convert(Object current) {
+			int p = 0;
+			Double[] r = new Double[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Double)
+					r[p] = ((Double) e);
+				else
+					r[p] = ((Number) e).doubleValue();
+				p++;
+			}
+			return r;
+		}
+	};
+
+	public static AMapper<boolean[]> MAPPER_PRIM_BOOL = new ArraysMapper<boolean[]>() {
+		@Override
+		public boolean[] convert(Object current) {
+			int p = 0;
+			boolean[] r = new boolean[((List<?>) current).size()];
+			for (Object e : ((List<?>) current))
+				r[p++] = ((Boolean) e).booleanValue();
+			return r;
+		}
+	};
+
+	public static AMapper<Boolean[]> MAPPER_BOOL = new ArraysMapper<Boolean[]>() {
+		@Override
+		public Boolean[] convert(Object current) {
+			int p = 0;
+			Boolean[] r = new Boolean[((List<?>) current).size()];
+			for (Object e : ((List<?>) current)) {
+				if (e == null)
+					continue;
+				if (e instanceof Boolean)
+					r[p] = ((Boolean) e).booleanValue();
+				else if (e instanceof Number)
+					r[p] = ((Number) e).intValue() != 0;
+				else
+					throw new RuntimeException("can not convert " + e + " toBoolean");
+				p++;
+			}
+			return r;
+		}
+	};
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/BeansMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/BeansMapper.java
@@ -1,0 +1,153 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.HashMap;
+
+import net.minidev.asm.Accessor;
+import net.minidev.asm.BeansAccess;
+import net.minidev.asm.ConvertDate;
+import net.minidev.json.JSONUtil;
+
+/**
+ * 
+ * @param <T>
+ * @deprecated Use the {@link net.minidev.json.writer.BeansMapper} class instead.
+ */
+@Deprecated
+@SuppressWarnings("unchecked")
+public abstract class BeansMapper<T> extends AMapper<T> {
+
+	public abstract Object getValue(Object current, String key);
+
+	public static class Bean<T> extends AMapper<T> {
+		final Class<T> clz;
+		final BeansAccess<T> ba;
+		final HashMap<String, Accessor> index;
+
+		public Bean(Class<T> clz) {
+			this.clz = clz;
+			this.ba = BeansAccess.get(clz, JSONUtil.JSON_SMART_FIELD_FILTER);
+			this.index = ba.getMap();
+		}
+
+		@Override
+		public void setValue(Object current, String key, Object value) {
+			ba.set((T) current, key, value);
+			// Accessor nfo = index.get(key);
+			// if (nfo == null)
+			// throw new RuntimeException("Can not set " + key + " field in " +
+			// clz);
+			// value = JSONUtil.convertTo(value, nfo.getType());
+			// ba.set((T) current, nfo.getIndex(), value);
+		}
+
+		public Object getValue(Object current, String key) {
+			return ba.get((T) current, key);
+			// Accessor nfo = index.get(key);
+			// if (nfo == null)
+			// throw new RuntimeException("Can not set " + key + " field in " +
+			// clz);
+			// return ba.get((T) current, nfo.getIndex());
+		}
+
+		@Override
+		public Type getType(String key) {
+			Accessor nfo = index.get(key);
+			return nfo.getGenericType();
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			Accessor nfo = index.get(key);
+			if (nfo == null)
+				throw new RuntimeException("Can not find Array '" + key + "' field in " + clz);
+			return Mapper.getMapper(nfo.getGenericType());
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			Accessor f = index.get(key);
+			if (f == null)
+				throw new RuntimeException("Can not find Object '" + key + "' field in " + clz);
+			return Mapper.getMapper(f.getGenericType());
+		}
+
+		@Override
+		public Object createObject() {
+			return ba.newInstance();
+		}
+	}
+
+	public static class BeanNoConv<T> extends AMapper<T> {
+		final Class<T> clz;
+		final BeansAccess<T> ba;
+		final HashMap<String, Accessor> index;
+
+		public BeanNoConv(Class<T> clz) {
+			this.clz = clz;
+			this.ba = BeansAccess.get(clz, JSONUtil.JSON_SMART_FIELD_FILTER);
+			this.index = ba.getMap();
+		}
+
+		@Override
+		public void setValue(Object current, String key, Object value) {
+			ba.set((T) current, key, value);
+		}
+
+		public Object getValue(Object current, String key) {
+			return ba.get((T) current, key);
+		}
+
+		@Override
+		public Type getType(String key) {
+			Accessor nfo = index.get(key);
+			return nfo.getGenericType();
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			Accessor nfo = index.get(key);
+			if (nfo == null)
+				throw new RuntimeException("Can not set " + key + " field in " + clz);
+			return Mapper.getMapper(nfo.getGenericType());
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			Accessor f = index.get(key);
+			if (f == null)
+				throw new RuntimeException("Can not set " + key + " field in " + clz);
+			return Mapper.getMapper(f.getGenericType());
+		}
+
+		@Override
+		public Object createObject() {
+			return ba.newInstance();
+		}
+	}
+	
+	public static AMapper<Date> MAPPER_DATE = new ArraysMapper<Date>() {
+		@Override
+		public Date convert(Object current) {
+			return ConvertDate.convertToDate(current);
+		}
+	};
+
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/CollectionMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/CollectionMapper.java
@@ -1,0 +1,252 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.List;
+import java.util.Map;
+
+import net.minidev.asm.BeansAccess;
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONObject;
+import net.minidev.json.JSONUtil;
+
+/**
+ * @deprecated Use the {@link net.minidev.json.writer.CollectionMapper} class instead.
+ */
+@Deprecated
+public class CollectionMapper {
+
+	public static class MapType<T> extends AMapper<T> {
+		final ParameterizedType type;
+		final Class<?> rawClass;
+		final Class<?> instance;
+		final BeansAccess<?> ba;
+
+		final Type keyType;
+		final Type valueType;
+
+		final Class<?> keyClass;
+		final Class<?> valueClass;
+
+		AMapper<?> subMapper;
+
+		public MapType(ParameterizedType type) {
+			this.type = type;
+			this.rawClass = (Class<?>) type.getRawType();
+			if (rawClass.isInterface())
+				instance = JSONObject.class;
+			else
+				instance = rawClass;
+			ba = BeansAccess.get(instance, JSONUtil.JSON_SMART_FIELD_FILTER);
+
+			keyType = type.getActualTypeArguments()[0];
+			valueType = type.getActualTypeArguments()[1];
+			if (keyType instanceof Class)
+				keyClass = (Class<?>) keyType;
+			else
+				keyClass = (Class<?>) ((ParameterizedType) keyType).getRawType();
+			if (valueType instanceof Class)
+				valueClass = (Class<?>) valueType;
+			else
+				valueClass = (Class<?>) ((ParameterizedType) valueType).getRawType();
+		}
+
+		@Override
+		public Object createObject() {
+			try {
+				return instance.newInstance();
+			} catch (InstantiationException e) {
+				e.printStackTrace();
+			} catch (IllegalAccessException e) {
+				e.printStackTrace();
+			}
+			return null;
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			if (subMapper == null)
+				subMapper = Mapper.getMapper(valueType);
+			return subMapper;
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			if (subMapper == null)
+				subMapper = Mapper.getMapper(valueType);
+			return subMapper;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void setValue(Object current, String key, Object value) {
+			((Map<Object, Object>) current).put(JSONUtil.convertToX(key, keyClass),
+					JSONUtil.convertToX(value, valueClass));
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Object getValue(Object current, String key) {
+			return ((Map<String, Object>) current).get(JSONUtil.convertToX(key, keyClass));
+		}
+
+		@Override
+		public Type getType(String key) {
+			return type;
+		}
+	};
+
+	public static class MapClass<T> extends AMapper<T> {
+		final Class<?> type;
+		final Class<?> instance;
+		final BeansAccess<?> ba;
+
+		AMapper<?> subMapper;
+
+		public MapClass(Class<?> type) {
+			this.type = type;
+			if (type.isInterface())
+				this.instance = JSONObject.class;
+			else
+				this.instance = type;
+			this.ba = BeansAccess.get(instance, JSONUtil.JSON_SMART_FIELD_FILTER);
+		}
+
+		@Override
+		public Object createObject() {
+			return ba.newInstance();
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			return DefaultMapper.DEFAULT; // _ARRAY
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			return DefaultMapper.DEFAULT; // _MAP
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void setValue(Object current, String key, Object value) {
+			((Map<String, Object>) current).put(key, value);
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public Object getValue(Object current, String key) {
+			return ((Map<String, Object>) current).get(key);
+		}
+
+		@Override
+		public Type getType(String key) {
+			return type;
+		}
+	};
+
+	public static class ListType<T> extends AMapper<T> {
+		final ParameterizedType type;
+		final Class<?> rawClass;
+		final Class<?> instance;
+		final BeansAccess<?> ba;
+
+		final Type valueType;
+		final Class<?> valueClass;
+
+		AMapper<?> subMapper;
+
+		public ListType(ParameterizedType type) {
+			this.type = type;
+			this.rawClass = (Class<?>) type.getRawType();
+			if (rawClass.isInterface())
+				instance = JSONArray.class;
+			else
+				instance = rawClass;
+			ba = BeansAccess.get(instance, JSONUtil.JSON_SMART_FIELD_FILTER); // NEW
+			valueType = type.getActualTypeArguments()[0];
+			if (valueType instanceof Class)
+				valueClass = (Class<?>) valueType;
+			else
+				valueClass = (Class<?>) ((ParameterizedType) valueType).getRawType();
+		}
+
+		@Override
+		public Object createArray() {
+			return ba.newInstance();
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			if (subMapper == null)
+				subMapper = Mapper.getMapper(type.getActualTypeArguments()[0]);
+			return subMapper;
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			if (subMapper == null)
+				subMapper = Mapper.getMapper(type.getActualTypeArguments()[0]);
+			return subMapper;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void addValue(Object current, Object value) {
+			((List<Object>) current).add(JSONUtil.convertToX(value, valueClass));
+		}
+	};
+
+	public static class ListClass<T> extends AMapper<T> {
+		final Class<?> type;
+		final Class<?> instance;
+		final BeansAccess<?> ba;
+
+		AMapper<?> subMapper;
+
+		public ListClass(Class<?> clazz) {
+			this.type = clazz;
+			if (clazz.isInterface())
+				instance = JSONArray.class;
+			else
+				instance = clazz;
+			ba = BeansAccess.get(instance, JSONUtil.JSON_SMART_FIELD_FILTER);
+		}
+
+		@Override
+		public Object createArray() {
+			return ba.newInstance();
+		}
+
+		@Override
+		public AMapper<?> startArray(String key) {
+			return DefaultMapper.DEFAULT;// _ARRAY;
+		}
+
+		@Override
+		public AMapper<?> startObject(String key) {
+			return DefaultMapper.DEFAULT;// _MAP;
+		}
+
+		@SuppressWarnings("unchecked")
+		@Override
+		public void addValue(Object current, Object value) {
+			((List<Object>) current).add(value);
+		}
+	};
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/CompessorMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/CompessorMapper.java
@@ -1,0 +1,219 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.io.IOException;
+
+import net.minidev.json.JSONStyle;
+import net.minidev.json.JSONValue;
+
+/**
+ * @deprecated Use the {@link net.minidev.json.writer.CompessorMapper} class instead.
+ */
+@Deprecated
+public class CompessorMapper extends AMapper<CompessorMapper> {
+	private Appendable out;
+	private JSONStyle compression;
+	private Boolean _isObj;
+	private boolean needSep = false;
+	private boolean isOpen = false;
+	private boolean isClosed = false;
+
+	// private boolean isRoot = false;
+
+	private boolean isArray() {
+		return _isObj == Boolean.FALSE;
+	}
+
+	private boolean isObject() {
+		return _isObj == Boolean.TRUE;
+	}
+
+	private boolean isCompressor(Object obj) {
+		return obj instanceof CompessorMapper;
+	}
+
+	public CompessorMapper(Appendable out, JSONStyle compression) {
+		this(out, compression, null);
+		// isRoot = true;
+	}
+
+	public CompessorMapper(Appendable out, JSONStyle compression, Boolean isObj) {
+		this.out = out;
+		this.compression = compression;
+		this._isObj = isObj;
+		// System.out.println("new CompressorMapper isObj:" + isObj);
+	}
+
+	@Override
+	public AMapper<?> startObject(String key) throws IOException {
+		open(this);
+		startKey(key);
+		// System.out.println("startObject " + key);
+		CompessorMapper r = new CompessorMapper(out, compression, true);
+		open(r);
+		return r;
+	}
+
+	@Override
+	public AMapper<?> startArray(String key) throws IOException {
+		open(this);
+		startKey(key);
+		// System.out.println("startArray " + key);
+		CompessorMapper r = new CompessorMapper(out, compression, false);
+		open(r);
+		return r;
+	}
+
+	private void startKey(String key) throws IOException {
+		addComma();
+		// if (key == null)
+		// return;
+		if (isArray())
+			return;
+		if (!compression.mustProtectKey(key))
+			out.append(key);
+		else {
+			out.append('"');
+			JSONValue.escape(key, out, compression);
+			out.append('"');
+		}
+		out.append(':');
+	}
+
+	@Override
+	public void setValue(Object current, String key, Object value) throws IOException {
+		// System.out.println("setValue(" + key + "," + value + ")");
+		// if comprossor => data allready writed
+		if (isCompressor(value)) {
+			addComma();
+			return;
+		}
+		startKey(key);
+		writeValue(value);
+	}
+
+	@Override
+	public void addValue(Object current, Object value) throws IOException {
+		// System.out.println("add value" + value);
+		// if (!isCompressor(value))
+		addComma();
+		writeValue(value);
+	}
+
+	private void addComma() throws IOException {
+		if (needSep) {
+			out.append(',');
+			// needSep = false;
+		} else {
+			needSep = true;
+		}
+	}
+
+	private void writeValue(Object value) throws IOException {
+		if (value instanceof String) {
+			if (!compression.mustProtectValue((String) value))
+				out.append((String) value);
+			else {
+				out.append('"');
+				JSONValue.escape((String) value, out, compression);
+				out.append('"');
+			}
+			// needSep = true;
+		} else {
+			if (isCompressor(value)) {
+				close(value);
+				// needSep = true;
+			} else {
+				JSONValue.writeJSONString(value, out, compression);
+				// needSep = true;
+			}
+		}
+	}
+
+	@Override
+	public Object createObject() {
+		// System.out.println("createObject");
+		this._isObj = true;
+		try {
+			open(this);
+		} catch (Exception e) {
+		}
+		// if (this.isUnknow() && isRoot) { // && isRoot
+		// this._isObj = true;
+		// try {
+		// out.append('{'); // 1
+		// } catch (Exception e) {
+		// }
+		// }
+		return this;
+	}
+
+	@Override
+	public Object createArray() {
+		// System.out.println("createArray");
+		this._isObj = false;
+		try {
+			open(this);
+		} catch (Exception e) {
+		}
+		return this;
+	}
+
+	public CompessorMapper convert(Object current) {
+		try {
+			close(current);
+			return this;
+		} catch (Exception e) {
+			return this;
+		}
+	}
+
+	private void close(Object obj) throws IOException {
+		if (!isCompressor(obj))
+			return;
+		if (((CompessorMapper) obj).isClosed)
+			return;
+		((CompessorMapper) obj).isClosed = true;
+		if (((CompessorMapper) obj).isObject()) {
+			// System.out.println("convert }");
+			out.append('}');
+			needSep = true;
+		} else if (((CompessorMapper) obj).isArray()) {
+			// System.out.println("convert ]");
+			out.append(']');
+			needSep = true;
+		}
+	}
+
+	private void open(Object obj) throws IOException {
+		if (!isCompressor(obj))
+			return;
+		if (((CompessorMapper) obj).isOpen)
+			return;
+		((CompessorMapper) obj).isOpen = true;
+		if (((CompessorMapper) obj).isObject()) {
+			// System.out.println("open {");
+			out.append('{');
+			needSep = false;
+		} else if (((CompessorMapper) obj).isArray()) {
+			// System.out.println("open [");
+			out.append('[');
+			needSep = false;
+		}
+	}
+
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/DefaultMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/DefaultMapper.java
@@ -1,0 +1,63 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONAwareEx;
+import net.minidev.json.JSONObject;
+
+/**
+ * @param <T>
+ * @deprecated Use the {@link net.minidev.json.writer.DefaultMapper} class instead.
+ */
+@Deprecated
+public class DefaultMapper<T> extends AMapper<T> {
+	private DefaultMapper() {
+	}
+
+	public static AMapper<JSONAwareEx> DEFAULT = new DefaultMapper<JSONAwareEx>();
+
+	@Override
+	public AMapper<JSONAwareEx> startObject(String key) {
+		return DEFAULT;
+	}
+
+	@Override
+	public AMapper<JSONAwareEx> startArray(String key) {
+		return DEFAULT;
+	}
+
+	@Override
+	public Object createObject() {
+		return new JSONObject();
+	}
+
+	@Override
+	public Object createArray() {
+		return new JSONArray();
+	}
+
+	@Override
+	public void setValue(Object current, String key, Object value) {
+		((JSONObject) current).put(key, value);
+	}
+
+	@Override
+	public void addValue(Object current, Object value) {
+		((JSONArray) current).add(value);
+	}
+
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/DefaultMapperCollection.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/DefaultMapperCollection.java
@@ -1,0 +1,78 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.lang.reflect.Constructor;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * @param <T>
+ * @deprecated Use the {@link DefaultMapperCollection} class instead.
+ */
+@Deprecated
+public class DefaultMapperCollection<T> extends AMapper<T> {
+	Class<T> clz;
+	//? extends Collection
+	public DefaultMapperCollection(Class<T> clz) {
+		this.clz = clz;
+	}
+
+	// public static AMapper<JSONAwareEx> DEFAULT = new
+	// DefaultMapperCollection<JSONAwareEx>();
+	@Override
+	public AMapper<T> startObject(String key) {
+		return this;
+	}
+
+	@Override
+	public AMapper<T> startArray(String key) {
+		return this;
+	}
+
+	@Override
+	public Object createObject() {
+		try {
+			Constructor<T> c = clz.getConstructor();
+			return c.newInstance();
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	@Override
+	public Object createArray() {
+		try {
+			Constructor<T> c = clz.getConstructor();
+			return c.newInstance();
+		} catch (Exception e) {
+			return null;
+		}
+	}
+
+	@SuppressWarnings({ "unchecked"})
+	@Override
+	public void setValue(Object current, String key, Object value) {
+		((Map<String, Object>) current).put(key, value);
+	}
+
+	@SuppressWarnings("unchecked")
+	@Override
+	public void addValue(Object current, Object value) {
+		((List<Object>) current).add(value);
+	}
+
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/DefaultMapperOrdered.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/DefaultMapperOrdered.java
@@ -1,0 +1,63 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONAwareEx;
+
+/**
+ * @deprecated Use the {@link net.minidev.json.writer.DefaultMapperOrdered} class instead.	
+ */
+@Deprecated
+public class DefaultMapperOrdered extends AMapper<JSONAwareEx> {
+	private DefaultMapperOrdered() {
+	};
+
+	public static AMapper<JSONAwareEx> DEFAULT = new DefaultMapperOrdered();
+
+	@Override
+	public AMapper<JSONAwareEx> startObject(String key) {
+		return DEFAULT;
+	}
+
+	@Override
+	public AMapper<JSONAwareEx> startArray(String key) {
+		return DEFAULT;
+	}
+
+	@SuppressWarnings("unchecked")
+	public void setValue(Object current, String key, Object value) {
+		((Map<String, Object>) current).put(key, value);
+	}
+
+	@Override
+	public Object createObject() {
+		return new LinkedHashMap<String, Object>();
+	}
+
+	@Override
+	public void addValue(Object current, Object value) {
+		((JSONArray) current).add(value);
+	}
+
+	@Override
+	public Object createArray() {
+		return new JSONArray();
+	}
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/FakeMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/FakeMapper.java
@@ -1,0 +1,55 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * @deprecated Use the {@link net.minidev.json.writer.FakeMapper} class instead.
+ */
+@Deprecated
+public class FakeMapper extends AMapper<Object> {
+	private FakeMapper() {
+	}
+
+	public static AMapper<Object> DEFAULT = new FakeMapper();
+
+	@Override
+	public AMapper<?> startObject(String key) {
+		return this;
+	}
+
+	@Override
+	public AMapper<?> startArray(String key) {
+		return this;
+	}
+
+	@Override
+	public void setValue(Object current, String key, Object value) {
+	}
+
+	@Override
+	public void addValue(Object current, Object value) {
+	}
+
+	@Override
+	public Object createObject() {
+		return null;
+	}
+
+	@Override
+	public Object createArray() {
+		return null;
+	}
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/Mapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/Mapper.java
@@ -1,0 +1,149 @@
+package net.minidev.json.mapper;
+
+/*
+ *    Copyright 2011 JSON-SMART authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+import net.minidev.json.JSONArray;
+import net.minidev.json.JSONAware;
+import net.minidev.json.JSONAwareEx;
+import net.minidev.json.JSONObject;
+import net.minidev.json.writer.JsonReader;
+
+/**
+ * @deprecated Use the {@link JsonReader} class instead.
+ */
+@Deprecated
+public class Mapper {
+	private final static ConcurrentHashMap<Type, AMapper<?>> cache;
+	static {
+		cache = new ConcurrentHashMap<Type, AMapper<?>>(100);
+
+		cache.put(Date.class, BeansMapper.MAPPER_DATE);
+
+		cache.put(int[].class, ArraysMapper.MAPPER_PRIM_INT);
+		cache.put(Integer[].class, ArraysMapper.MAPPER_INT);
+
+		cache.put(short[].class, ArraysMapper.MAPPER_PRIM_INT);
+		cache.put(Short[].class, ArraysMapper.MAPPER_INT);
+
+		cache.put(long[].class, ArraysMapper.MAPPER_PRIM_LONG);
+		cache.put(Long[].class, ArraysMapper.MAPPER_LONG);
+
+		cache.put(byte[].class, ArraysMapper.MAPPER_PRIM_BYTE);
+		cache.put(Byte[].class, ArraysMapper.MAPPER_BYTE);
+
+		cache.put(char[].class, ArraysMapper.MAPPER_PRIM_CHAR);
+		cache.put(Character[].class, ArraysMapper.MAPPER_CHAR);
+
+		cache.put(float[].class, ArraysMapper.MAPPER_PRIM_FLOAT);
+		cache.put(Float[].class, ArraysMapper.MAPPER_FLOAT);
+
+		cache.put(double[].class, ArraysMapper.MAPPER_PRIM_DOUBLE);
+		cache.put(Double[].class, ArraysMapper.MAPPER_DOUBLE);
+
+		cache.put(boolean[].class, ArraysMapper.MAPPER_PRIM_BOOL);
+		cache.put(Boolean[].class, ArraysMapper.MAPPER_BOOL);
+
+		cache.put(JSONAwareEx.class, DefaultMapper.DEFAULT);
+		cache.put(JSONAware.class, DefaultMapper.DEFAULT);
+		cache.put(JSONArray.class, DefaultMapper.DEFAULT);
+		cache.put(JSONObject.class, DefaultMapper.DEFAULT);
+	}
+
+	public static <T> void register(Class<T> type, AMapper<T> mapper) {
+		cache.put(type, mapper);
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> AMapper<T> getMapper(Type type) {
+		if (type instanceof ParameterizedType)
+			return getMapper((ParameterizedType) type);
+		return getMapper((Class<T>) type);
+	}
+
+	/**
+	 * Get the corresponding mapper Class, or create it on first call
+	 * 
+	 * @param type to be map
+	 */
+	public static <T> AMapper<T> getMapper(Class<T> type) {
+		// look for cached Mapper
+		@SuppressWarnings("unchecked")
+		AMapper<T> map = (AMapper<T>) cache.get(type);
+		if (map != null)
+			return map;
+		/*
+		 * Special handle
+		 */
+		if (type instanceof Class) {
+			if (Map.class.isAssignableFrom(type))
+				map = new DefaultMapperCollection<T>(type);
+			else if (List.class.isAssignableFrom(type))
+				map = new DefaultMapperCollection<T>(type);
+			if (map != null) {
+				cache.put(type, map);
+				return map;
+			}
+		}
+
+		if (type.isArray())
+			map = new ArraysMapper.GenericMapper<T>(type);
+		else if (List.class.isAssignableFrom(type))
+			map = new CollectionMapper.ListClass<T>(type);
+		else if (Map.class.isAssignableFrom(type))
+			map = new CollectionMapper.MapClass<T>(type);
+		else
+			// use bean class
+			map = new BeansMapper.Bean<T>(type);
+		cache.putIfAbsent(type, map);
+		return map;
+	}
+
+	@SuppressWarnings("unchecked")
+	public static <T> AMapper<T> getMapper(ParameterizedType type) {
+		AMapper<T> map = (AMapper<T>) cache.get(type);
+		if (map != null)
+			return map;
+
+		// Type t2 = type.getRawType();
+		// if (t2 instanceof Class) {
+		// Class t3 = (Class) t2;
+		// if (Map.class.isAssignableFrom(t3)) {
+		// map = new DefaultMapperCollection(t3);
+		// cache.put(type, map);
+		// } else if (List.class.isAssignableFrom(t3)) {
+		// map = new DefaultMapperCollection(t3);
+		// cache.put(type, map);
+		// }
+		// return map;
+		// }
+
+		// System.out.println("add in ParamCache " + type);
+		Class<T> clz = (Class<T>) type.getRawType();
+		if (List.class.isAssignableFrom(clz))
+			map = new CollectionMapper.ListType<T>(type);
+		else if (Map.class.isAssignableFrom(clz))
+			map = new CollectionMapper.MapType<T>(type);
+		cache.putIfAbsent(type, map);
+		return map;
+	}
+}

--- a/json-smart/src/main/java/net/minidev/json/mapper/UpdaterMapper.java
+++ b/json-smart/src/main/java/net/minidev/json/mapper/UpdaterMapper.java
@@ -1,0 +1,97 @@
+package net.minidev.json.mapper;
+
+import java.io.IOException;
+import java.lang.reflect.Type;
+
+import net.minidev.json.parser.ParseException;
+
+/**
+ * @param <T>
+ * @deprecated Use the {@link net.minidev.json.writer.UpdaterMapper} class instead.
+ */
+@Deprecated
+public class UpdaterMapper<T> extends AMapper<T> {
+	final T obj;
+	final AMapper<?> mapper;
+
+	public UpdaterMapper(T obj) {
+		if (obj == null)
+			throw new NullPointerException("can not update null Object");
+		this.obj = obj;
+		this.mapper = (AMapper<?>) Mapper.getMapper(obj.getClass());
+	}
+
+	public UpdaterMapper(T obj, Type type) {
+		if (obj == null)
+			throw new NullPointerException("can not update null Object");
+		this.obj = obj;
+		this.mapper = (AMapper<?>) Mapper.getMapper(type);
+	}
+
+	/**
+	 * called when json-smart parser meet an object key
+	 */
+	public AMapper<?> startObject(String key) throws ParseException, IOException {
+		Object bean = mapper.getValue(obj, key);
+		if (bean == null)
+			return mapper.startObject(key);
+		return new UpdaterMapper<Object>(bean, mapper.getType(key));
+	}
+
+	/**
+	 * called when json-smart parser start an array.
+	 * 
+	 * @param key
+	 *            the destination key name, or null.
+	 */
+	public AMapper<?> startArray(String key) throws ParseException, IOException {
+		// if (obj != null)
+		return mapper.startArray(key);
+	}
+
+	/**
+	 * called when json-smart done parsing a value
+	 */
+	public void setValue(Object current, String key, Object value) throws ParseException, IOException {
+		// if (obj != null)
+		mapper.setValue(current, key, value);
+	}
+
+	/**
+	 * add a value in an array json object.
+	 */
+	public void addValue(Object current, Object value) throws ParseException, IOException {
+		// if (obj != null)
+		mapper.addValue(current, value);
+	}
+
+	/**
+	 * use to instantiate a new object that will be used as an object
+	 */
+	public Object createObject() {
+		if (obj != null)
+			return obj;
+		return mapper.createObject();
+	}
+
+	/**
+	 * use to instantiate a new object that will be used as an array
+	 */
+	public Object createArray() {
+		if (obj != null)
+			return obj;
+		return mapper.createArray();
+	}
+
+	/**
+	 * Allow a mapper to converte a temprary structure to the final data format.
+	 * 
+	 * example: convert an List<Integer> to an int[]
+	 */
+	@SuppressWarnings("unchecked")
+	public T convert(Object current) {
+		if (obj != null)
+			return obj;
+		return (T) mapper.convert(current);
+	}
+}


### PR DESCRIPTION
From https://github.com/netplex/json-smart-v2/tree/f5260dc716e14a89d9a9549722558b74fa70fc25
deprecated the classes. (Hopefully that was the released version of
this project.)
