### PR TITLE
Remove the inlined ASM dependency in smart-accessors

### DIFF
--- a/accessors-smart/pom.xml
+++ b/accessors-smart/pom.xml
@@ -3,7 +3,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>net.minidev</groupId>
     <artifactId>accessors-smart</artifactId>
-    <version>1.1</version>
+    <version>1.2-SNAPSHOT</version>
     <name>ASM based accessors helper used by json-smart</name>
     <description>Java reflect give poor performance on getter setter an constructor calls, accessors-smart use ASM to speed up those calls.
     </description>
@@ -257,8 +257,6 @@
                         <Export-Package>
                             net.minidev.asm, net.minidev.asm.ex
                         </Export-Package>
-                        <!-- Private-Package></Private-Package -->
-                        <Embed-Dependency>asm;groupId=org.ow2.asm;inline=true</Embed-Dependency>
                     </instructions>
                 </configuration>
             </plugin>


### PR DESCRIPTION
Addresses #20 

Example output when shading `asm` and `accessors-smart` into the same assembly. After the changes were applied the overlapping classes error was resolved.

```
asm-5.1.jar, accessors-smart-1.1.jar define 25 overlapping classes:
  - org.objectweb.asm.Type
  - org.objectweb.asm.AnnotationVisitor
  - org.objectweb.asm.MethodVisitor
  - org.objectweb.asm.Attribute
  - org.objectweb.asm.MethodWriter
  - org.objectweb.asm.Handler
  - org.objectweb.asm.ByteVector
  - org.objectweb.asm.Opcodes
  - org.objectweb.asm.signature.SignatureReader
  - org.objectweb.asm.FieldVisitor
  - 15 more...
```
