### PR TITLE
Double and BigDecimal test value added and solution

### DIFF
--- a/json-smart/src/main/java/net/minidev/json/parser/JSONParserBase.java
+++ b/json-smart/src/main/java/net/minidev/json/parser/JSONParserBase.java
@@ -141,9 +141,13 @@ abstract class JSONParserBase {
 			checkLeadinZero();
 		if (!useHiPrecisionFloat)
 			return Float.parseFloat(xs);
-		if (xs.length() > 18) // follow JSonIJ parsing method
-			return new BigDecimal(xs);
-		return Double.parseDouble(xs);
+		double value = Double.parseDouble(xs);
+		if (xs.length() > 18) { // follow JSonIJ parsing method
+			if(!String.valueOf(value).equals(xs)) {
+				return new BigDecimal(xs);
+			}
+		}
+		return value;
 	}
 
 	/**

--- a/json-smart/src/test/java/net/minidev/json/test/TestFloat.java
+++ b/json-smart/src/test/java/net/minidev/json/test/TestFloat.java
@@ -8,7 +8,7 @@ import net.minidev.json.parser.JSONParser;
 public class TestFloat extends TestCase {
 	public static String[] TRUE_NUMBERS = new String[] { "1.0", "123.456", "1.0E1", "123.456E12", "1.0E+1",
 			"123.456E+12", "1.0E-1", "123.456E-12", "1.0e1", "123.456e12", "1.0e+1", "123.456e+12", "1.0e-1",
-			"123.456e-12" };
+			"123.456e-12", "0.12345678912345678" };
 
 	public static String[] FALSE_NUMBERS = new String[] { "1.0%", "123.45.6", "1.0E", "++123.456E12", "+-01",
 			"1.0E+1.2" };


### PR DESCRIPTION
In some cases we found the problem. If we try to parse Double from json like 0.12345678912345678 parser return BigDecimal value, and matchers return assertion failure, but this number can be parse to Double. Spring test use your library and we found that problem there. I was add test value to TestFloat class and write some solution in JSONParserBase extractFloat method for that case. I think the solution isn't good, but now I don't know how I can fix it better.