### PR TITLE
Bump org.ow2.asm:asm from 5.0.4 to 6.2.1

### DIFF
--- a/accessors-smart/pom.xml
+++ b/accessors-smart/pom.xml
@@ -46,7 +46,7 @@
         <dependency>
             <groupId>org.ow2.asm</groupId>
             <artifactId>asm</artifactId>
-            <version>5.0.4</version>
+            <version>6.2.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
ASM 6.2.1 is compatible with Java 11 in both classpath mode and module-path mode.