### PR TITLE
[#73] Avoid `String` creation using system default charset

### DIFF
--- a/json-smart/src/main/java/net/minidev/json/parser/JSONParserByteArray.java
+++ b/json-smart/src/main/java/net/minidev/json/parser/JSONParserByteArray.java
@@ -19,6 +19,9 @@ import static net.minidev.json.parser.ParseException.ERROR_UNEXPECTED_EOF;
 import net.minidev.json.JSONValue;
 import net.minidev.json.writer.JsonReaderI;
 
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+
 /**
  * Parser for JSON text. Please note that JSONParser is NOT thread-safe.
  * 
@@ -59,7 +62,7 @@ class JSONParserByteArray extends JSONParserMemory {
 	}
 
 	protected void extractString(int beginIndex, int endIndex) {
-		xs = new String(in, beginIndex, endIndex - beginIndex);
+		xs = new String(in, beginIndex, endIndex - beginIndex, StandardCharsets.UTF_8);
 	}
 
 	protected void extractStringTrim(int start, int stop) {
@@ -71,7 +74,7 @@ class JSONParserByteArray extends JSONParserMemory {
 		while ((start < stop) && (val[stop - 1] <= ' ')) {
 			stop--;
 		}
-		xs = new String(in, start, stop - start);
+		xs = new String(in, start, stop - start, StandardCharsets.UTF_8);
 	}
 
 	protected int indexOf(char c, int pos) {

--- a/json-smart/src/test/java/net/minidev/json/test/TestUtf8.java
+++ b/json-smart/src/test/java/net/minidev/json/test/TestUtf8.java
@@ -19,7 +19,8 @@ public class TestUtf8 {
 				Arguments.of("Russian", "Русский"), Arguments.of("Farsi", "فارسی"), Arguments.of("Korean", "한국어"),
 				Arguments.of("Armenian", "Հայերեն"), Arguments.of("Hindi", "हिन्दी"), Arguments.of("Hebrew", "עברית"),
 				Arguments.of("Chinese", "中文"), Arguments.of("Amharic", "አማርኛ"), Arguments.of("Malayalam", "മലയാളം"),
-				Arguments.of("Assyrian Neo-Aramaic", "ܐܬܘܪܝܐ"), Arguments.of("Georgian", "მარგალური"));
+				Arguments.of("Assyrian Neo-Aramaic", "ܐܬܘܪܝܐ"), Arguments.of("Georgian", "მარგალური"),
+				Arguments.of("Emojis", "🐶🐱🐭🐹🐰🦊🐻🐼🐻‍❄🐨🐯🦁🐮🐷🐽🐸🐵🙈🙉🙊🐒🐔🐧🐦🐤🐣🐥🦆🦅🦉🦇🐺🐗🐴🦄🐝🐛"));
 	};
 
 	@ParameterizedTest


### PR DESCRIPTION
Used `StandardCharsets.UTF_8` to create `String` in `JSONParserByteArray` to avoid dependency on system's default charset and added additional emoji test.

Fixes #73