### PR TITLE
Fix the incorrect double compare with e,E+,e+

### DIFF
--- a/json-smart/src/test/java/net/minidev/json/test/TestBigDigitUnrestricted.java
+++ b/json-smart/src/test/java/net/minidev/json/test/TestBigDigitUnrestricted.java
@@ -10,7 +10,7 @@ import net.minidev.json.parser.JSONParser;
 import org.junit.jupiter.api.Test;
 
 public class TestBigDigitUnrestricted {
-	public static String[] VALID_DOUBLE_JSON = new String[] {"{\"v\":0.12345678912345678}"}; 
+	public static String[] VALID_DOUBLE_JSON = new String[] {"{\"v\":0.12345678912345678}", "\"v\":\"1.7976931348623157E308\"", "\"v\":\"1.7976931348623157E+308\"", "\"v\":\"1.7976931348623157e+308\""};
 	
 	@Test
 	public void testRestrictedBigDigit() throws Exception {


### PR DESCRIPTION
The `use extra CPU to check if the result can be return as double without precision lost` does not consider the case of double can appear `e` `E+` `e+`, but the double toString only shows `E`.
Which will lead to an incorrect compare failure.