### PR TITLE
Fix OSGi import package version for net.minidev.asm.

### DIFF
--- a/json-smart/pom.xml
+++ b/json-smart/pom.xml
@@ -236,6 +236,10 @@ limitations under the License.
 							net.minidev.json.reader,
 							net.minidev.json.writer
 						</Export-Package>
+						<Import-Package>
+							net.minidev.asm;version="1.0",
+							*
+						</Import-Package>
 					</instructions>
 				</configuration>
 			</plugin>


### PR DESCRIPTION
I am trying to deploy json-smart in an OSGi runtime, and found that it imports the `net.minidev.asm` package with a version range of `[2.5,3)`, taken from this snippet of `MANIFEST.MF`:

```
Import-Package: net.minidev.asm;version="[2.5,3)",net.minidev.json,net
 .minidev.json.annotate,net.minidev.json.parser,net.minidev.json.reade
 r,net.minidev.json.writer
```

However the [net.minidev:asm](https://search.maven.org/artifact/net.minidev/asm) JAR is up to version 1.0.2. I was able to load both json-smart and the asm bundles in my OSGi runtime by tweaking the import package configuration in the POM, to explicitly define the import version of `net.minidev.asm` as `1.0`. That produces the following `MANIFEST.MF` result:

```
Import-Package: net.minidev.asm;version="1.0",net.minidev.json,net.minid
 ev.json.annotate,net.minidev.json.parser,net.minidev.json.reader,net.mi
 nidev.json.writer
```